### PR TITLE
Bypass the pypi error when we try to publish a package twice

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,12 @@ task setup(type:Exec) {
 } 
 
 task publish(type:Exec) {
-   commandLine './publish.sh'
+   ignoreExitValue true
+   try {
+       commandLine './publish.sh'
+   } catch (all) {
+       println 'the archive probably already exist so no need to publish twice'
+   }
 } 
 
 


### PR DESCRIPTION
In most cases this will help us with process reentrance. We can still investigate specific publish issues by running the publish script directly.