### PR TITLE
Adding Task Error Policy

### DIFF
--- a/proactive/ProactiveBuilder.py
+++ b/proactive/ProactiveBuilder.py
@@ -84,6 +84,10 @@ class ProactiveTaskBuilder(ProactiveBuilder):
         """
         return self.proactive_task_model
 
+    def __create_task_error_policy__(self, _task_error_policy):
+        self.task_error_policy = self.proactive_factory.create_task_error_policy(_task_error_policy)
+        return self.task_error_policy
+
     def __create_script__(self):
         assert self.proactive_task_model.getScriptLanguage() is not None
         task_implementation = ''
@@ -196,6 +200,14 @@ class ProactiveTaskBuilder(ProactiveBuilder):
         self.script_task.setScript(task_script)
         self.script_task.setPreciousResult(self.proactive_task_model.getPreciousResult())
 
+        if self.proactive_task_model.hasTaskErrorPolicy():
+            self.logger.debug('Building and setting the task error policy')
+            self.script_task.setOnTaskError(
+                self.__create_task_error_policy__(
+                    self.proactive_task_model.getTaskErrorPolicy()
+                )
+            )
+        
         if self.proactive_task_model.hasForkEnvironment():
             self.logger.debug('Building and setting the fork environment')
             self.script_task.setForkEnvironment(

--- a/proactive/ProactiveFactory.py
+++ b/proactive/ProactiveFactory.py
@@ -195,3 +195,13 @@ class ProactiveFactory:
         :return: A StaxJobFactory object
         """
         return self.runtime_gateway.jvm.org.ow2.proactive.scheduler.common.job.factories.StaxJobFactory(True) # handleGlobalVariables=True
+
+
+    def create_task_error_policy(self, task_error_policy):
+        """
+        Create a ProActive task error policy.
+
+        :param policy: The error policy type ('continueJobExecution' or 'cancelJob').
+        :return: A OnTaskError object.
+        """
+        return self.runtime_gateway.jvm.org.ow2.proactive.scheduler.common.task.OnTaskError.getInstance(task_error_policy)

--- a/proactive/model/ProactiveTask.py
+++ b/proactive/model/ProactiveTask.py
@@ -45,6 +45,7 @@ class ProactiveTask(object):
         self.flow_script = None
         self.flow_block = None
         self.precious_result = False
+        self.task_error_policy = 'continueJobExecution'  # Default behavior
 
     def __str__(self):
         return self.getTaskName()
@@ -230,6 +231,15 @@ class ProactiveTask(object):
 
     def hasFlowBlock(self):
         return True if self.flow_block is not None else False
+        
+    def setTaskErrorPolicy(self, task_error_policy):
+        self.task_error_policy = task_error_policy
+
+    def getTaskErrorPolicy(self):
+        return self.task_error_policy
+
+    def hasTaskErrorPolicy(self):
+        return True if self.task_error_policy is not None else False
     
     def setSignals(self, taskSignals, scope="prescript"):
         if scope not in ['prescript', 'taskscript', 'postscript']:


### PR DESCRIPTION
In this PR:

Task Error Policy is added 
Two policies are defined: cancelJob and continueJobExecution
If an error occurs:
1. In case cancelJob is chosen: task will be Faulty and the following dependent tasks in the workflow won't be executed.
2. In case continueJobExecution is chosen: task will be Faulty and other dependent tasks in the workflow will continue execution.